### PR TITLE
+ metrics identifier resolver configuration control concept

### DIFF
--- a/metrics-boot/src/main/java/org/ametiste/metrics/boot/configuration/MetricsIdentifierResolverCoreConfguration.java
+++ b/metrics-boot/src/main/java/org/ametiste/metrics/boot/configuration/MetricsIdentifierResolverCoreConfguration.java
@@ -1,0 +1,23 @@
+package org.ametiste.metrics.boot.configuration;
+
+import org.ametiste.metrics.resolver.MetricsIdentifierResolver;
+import org.ametiste.metrics.resolver.PlainMetricsIdentifierResolver;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ *
+ * @since
+ */
+@Configuration
+public class MetricsIdentifierResolverCoreConfguration {
+
+    @Bean
+    @ConditionalOnProperty(prefix = MetricsProperties.PREFIX,
+            name = "core.identifier-resolver.enabled", matchIfMissing = true)
+    public MetricsIdentifierResolver coreIdentifierResolver() {
+        return new PlainMetricsIdentifierResolver();
+    }
+
+}

--- a/metrics-boot/src/main/java/org/ametiste/metrics/boot/configuration/MetricsIdentifierResolverCoreConfguration.java
+++ b/metrics-boot/src/main/java/org/ametiste/metrics/boot/configuration/MetricsIdentifierResolverCoreConfguration.java
@@ -14,7 +14,7 @@ import org.springframework.context.annotation.Configuration;
 public class MetricsIdentifierResolverCoreConfguration {
 
     @Bean
-    @ConditionalOnProperty(prefix = MetricsProperties.PREFIX,
+    @ConditionalOnProperty(prefix = MetricsProperties.PROPS_PREFIX,
             name = "core.identifier-resolver.enabled", matchIfMissing = true)
     public MetricsIdentifierResolver coreIdentifierResolver() {
         return new PlainMetricsIdentifierResolver();

--- a/metrics-boot/src/main/java/org/ametiste/metrics/boot/configuration/MetricsProperties.java
+++ b/metrics-boot/src/main/java/org/ametiste/metrics/boot/configuration/MetricsProperties.java
@@ -5,10 +5,13 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.stereotype.Component;
 
 @Component
-@ConfigurationProperties(prefix=MetricsProperties.PREFIX)
+@ConfigurationProperties(prefix=MetricsProperties.PROPS_PREFIX)
 public class MetricsProperties {
 
-    public static final String PREFIX = "org.ametiste.metrics";
+    /**
+     * Defines prefix name used to scope library properties.
+     */
+    public static final String PROPS_PREFIX = "org.ametiste.metrics";
 
     private Statsd statsd = new Statsd();
 

--- a/metrics-boot/src/main/java/org/ametiste/metrics/boot/configuration/MetricsProperties.java
+++ b/metrics-boot/src/main/java/org/ametiste/metrics/boot/configuration/MetricsProperties.java
@@ -5,11 +5,15 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.stereotype.Component;
 
 @Component
-@ConfigurationProperties(prefix="org.ametiste.metrics")
+@ConfigurationProperties(prefix=MetricsProperties.PREFIX)
 public class MetricsProperties {
 
+    public static final String PREFIX = "org.ametiste.metrics";
+
     private Statsd statsd = new Statsd();
+
     private Jmx jmx = new Jmx();
+
     private String prefix="";
 
     public Statsd getStatsd() {

--- a/metrics-boot/src/main/java/org/ametiste/metrics/boot/configuration/MetricsRoutingCoreConfiguration.java
+++ b/metrics-boot/src/main/java/org/ametiste/metrics/boot/configuration/MetricsRoutingCoreConfiguration.java
@@ -13,7 +13,7 @@ import java.util.List;
 import java.util.Map;
 
 @Configuration
-public class MetricsRoutingConfiguration {
+public class MetricsRoutingCoreConfiguration {
 
     @Autowired
     @CoreAggregator

--- a/metrics-boot/src/main/java/org/ametiste/metrics/boot/configuration/MetricsServiceConfiguration.java
+++ b/metrics-boot/src/main/java/org/ametiste/metrics/boot/configuration/MetricsServiceConfiguration.java
@@ -1,12 +1,10 @@
 package org.ametiste.metrics.boot.configuration;
 
 import org.ametiste.metrics.AggregatingMetricsService;
-import org.ametiste.metrics.MetricsAggregator;
 import org.ametiste.metrics.MetricsService;
-import org.ametiste.metrics.NullMetricsAggregator;
 import org.ametiste.metrics.aop.IdentifierResolver;
 import org.ametiste.metrics.container.MapContainer;
-import org.ametiste.metrics.resolver.PlainMetricsIdentifierResolver;
+import org.ametiste.metrics.resolver.MetricsIdentifierResolver;
 import org.ametiste.metrics.router.AggregatorsRouter;
 import org.ametiste.metrics.router.MappingAggregatorsRouter;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -18,7 +16,11 @@ import org.springframework.context.annotation.Import;
 import org.springframework.expression.spel.standard.SpelExpressionParser;
 
 @Configuration
-@Import({JmxConfiguration.class, StatsDConfiguration.class, MetricsRoutingConfiguration.class})
+@Import({
+        JmxConfiguration.class,
+        StatsDConfiguration.class,
+        MetricsRoutingCoreConfiguration.class,
+        MetricsIdentifierResolverCoreConfguration.class})
 @EnableConfigurationProperties(MetricsProperties.class)
 public class MetricsServiceConfiguration {
 
@@ -27,6 +29,9 @@ public class MetricsServiceConfiguration {
 
     @Autowired
     private MapContainer metricRoutingMap;
+
+    @Autowired
+    private MetricsIdentifierResolver identifierResolver;
 
     @Bean
     public AggregatorsRouter aggregatorsRouter() {
@@ -38,8 +43,9 @@ public class MetricsServiceConfiguration {
     public MetricsService metricsService() {
        return new AggregatingMetricsService(
                aggregatorsRouter(),
-               new PlainMetricsIdentifierResolver(),
-               properties.getPrefix());
+               identifierResolver,
+               properties.getPrefix()
+       );
     }
 
     @Bean

--- a/metrics-experimental/src/main/java/org/ametiste/metrics/experimental/activator/conditions/scopes/request/RequestScopeDetector.java
+++ b/metrics-experimental/src/main/java/org/ametiste/metrics/experimental/activator/conditions/scopes/request/RequestScopeDetector.java
@@ -33,7 +33,7 @@ public final class RequestScopeDetector {
         }
 
         try {
-            return Optional.of(((ServletRequestAttributes) RequestContextHolder.currentRequestAttributes())
+            return Optional.ofNullable(((ServletRequestAttributes) RequestContextHolder.currentRequestAttributes())
                     .getRequest().getParameter(parameterName))
                     .orElse("false")
                     .equals("true");

--- a/metrics-experimental/src/main/java/org/ametiste/metrics/experimental/staff/StaffPrefixResolverConfiguration.java
+++ b/metrics-experimental/src/main/java/org/ametiste/metrics/experimental/staff/StaffPrefixResolverConfiguration.java
@@ -1,12 +1,15 @@
 package org.ametiste.metrics.experimental.staff;
 
 import com.sun.org.apache.xpath.internal.operations.Variable;
+import org.ametiste.metrics.boot.configuration.MetricsProperties;
 import org.ametiste.metrics.experimental.activator.ResolverActivator;
 import org.ametiste.metrics.experimental.activator.conditions.scopes.request.EnabledByRequestParameter;
 import org.ametiste.metrics.experimental.activator.conditions.scopes.request.WithinRequestScope;
 import org.ametiste.metrics.experimental.resolver.templated.VariableBind;
 import org.ametiste.metrics.resolver.MetricsIdentifierResolver;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -15,14 +18,14 @@ import org.springframework.context.annotation.Configuration;
  * @since
  */
 @Configuration
-// TODO : I guess we need MetricsIdentifierResolver usage refactoring,
-// there is no way to inject my own resolver
+@EnableConfigurationProperties(StaffPrefixResolverProperties.class)
 public class StaffPrefixResolverConfiguration {
 
     @Autowired
     private StaffPrefixResolverProperties properties;
 
     @Bean
+    @ConditionalOnProperty(prefix = MetricsProperties.PREFIX, name = "staff.identifier-resolver.enabled")
     public MetricsIdentifierResolver staffPrefixResolver() {
         return new ResolverActivator(
                 new PrefixResolver(properties.getStaffMetricPrefix()),

--- a/metrics-experimental/src/main/java/org/ametiste/metrics/experimental/staff/StaffPrefixResolverConfiguration.java
+++ b/metrics-experimental/src/main/java/org/ametiste/metrics/experimental/staff/StaffPrefixResolverConfiguration.java
@@ -1,11 +1,9 @@
 package org.ametiste.metrics.experimental.staff;
 
-import com.sun.org.apache.xpath.internal.operations.Variable;
 import org.ametiste.metrics.boot.configuration.MetricsProperties;
 import org.ametiste.metrics.experimental.activator.ResolverActivator;
 import org.ametiste.metrics.experimental.activator.conditions.scopes.request.EnabledByRequestParameter;
 import org.ametiste.metrics.experimental.activator.conditions.scopes.request.WithinRequestScope;
-import org.ametiste.metrics.experimental.resolver.templated.VariableBind;
 import org.ametiste.metrics.resolver.MetricsIdentifierResolver;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
@@ -25,7 +23,7 @@ public class StaffPrefixResolverConfiguration {
     private StaffPrefixResolverProperties properties;
 
     @Bean
-    @ConditionalOnProperty(prefix = MetricsProperties.PREFIX, name = "staff.identifier-resolver.enabled")
+    @ConditionalOnProperty(prefix = MetricsProperties.PROPS_PREFIX, name = "staff.identifier-resolver.enabled")
     public MetricsIdentifierResolver staffPrefixResolver() {
         return new ResolverActivator(
                 new PrefixResolver(properties.getStaffMetricPrefix()),

--- a/metrics-experimental/src/main/java/org/ametiste/metrics/experimental/staff/StaffPrefixResolverConfiguration.java
+++ b/metrics-experimental/src/main/java/org/ametiste/metrics/experimental/staff/StaffPrefixResolverConfiguration.java
@@ -1,12 +1,11 @@
 package org.ametiste.metrics.experimental.staff;
 
-import com.sun.org.apache.xpath.internal.operations.Variable;
 import org.ametiste.metrics.experimental.activator.ResolverActivator;
 import org.ametiste.metrics.experimental.activator.conditions.scopes.request.EnabledByRequestParameter;
 import org.ametiste.metrics.experimental.activator.conditions.scopes.request.WithinRequestScope;
-import org.ametiste.metrics.experimental.resolver.templated.VariableBind;
 import org.ametiste.metrics.resolver.MetricsIdentifierResolver;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 


### PR DESCRIPTION
# Proposal

Trying to find a way to control _IdentifierResolver_ configuration. 

# Proposed Solution

Proposed method based on idea that only one _IdentifierResolver_ bean is exists within the context, and the process of this bean election during context initialization is controlled by the set of configuration properties. Method implies convention to add configuration properties which controls _resolver_ bean creation for each _core resolver_ as well as _custom resolvers_.

# Alternatives

Possible alternative of properties controlled creation process is conditional process based on criteria of bean existence, this method may introduce convention that defines and implies next initialization rule: if there is no other resolver beans within an application context, the core resolver bean is used._

But, this method would lead to error configuration, at firs in cases where some _resolvers_ may be configured indirectly through third dependencies that would lead to configuration clash and unexpected and unpredictable behaviours when more then one _resolver_ bean is exists. 

# Implementation

Implemented configuration module provides _core identifier resolver_ which creation is enabled by default, but could be disabled by the _org.ametiste.metrics.core.identifier-resolver.enabled_ property. So the core configuration variant must be usable for most of clients. Client configurations where other _identifier resolver_ is required should disable _core identifier resolver_ using provided property and enable desired _identifier resolver_.

_Spring Autowire_ mechanism of dependencies selection which reject configuration process if more than one bean of a type is exists will prevent possible configuration clashes through third dependencies.

For example, if some client wants to use _IdentifierTemplateResolver_, client configuration must disable creation of _core identifier_ and enable creation of _template resolver_ through configuration properties

```
org.ametiste.metrics.core.identifier-resolver.enabled=false
org.ametiste.metrics.staff.identifier-resolver.enabled=true
```

### Changes Details

Changes within the core configuration modules to support proposed configuration method: 

first, _MetricsServiceConfiguration_ now autowires a _MetricsIdentifierResolver_ bean and using it as dependency during _MetricsService_ bean creation;

second, _MetricsIdentifierResolverCoreConfguration_ added to provide _core identifier resolver_ that enabled by default and would be used at most of configurations;

third, _org.ametiste.metrics.core.identifier-resolver.enabled_ property added, this property is control should the core identifier resolver be created or not.