### PR TITLE
metrics service is now marked as default one

### DIFF
--- a/metrics-boot/src/main/java/org/ametiste/metrics/boot/configuration/MetricsServiceConfiguration.java
+++ b/metrics-boot/src/main/java/org/ametiste/metrics/boot/configuration/MetricsServiceConfiguration.java
@@ -7,6 +7,7 @@ import org.ametiste.metrics.resolver.MetricsIdentifierResolver;
 import org.ametiste.metrics.router.AggregatorsRouter;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -34,6 +35,7 @@ public class MetricsServiceConfiguration {
 
     @Bean
     @Qualifier("metricsService")
+    @ConditionalOnMissingBean
     public MetricsService metricsService() {
         return new AggregatingMetricsService(
                 aggregatorsRouter,


### PR DESCRIPTION
 - is only created when no other metricsservice bean exists in confuguration